### PR TITLE
fix: bump music-meta version to correct buf.readInt16BE error; allow spaces in file name;

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "springroll-automated-qa",
-  "version": "1.1.0",
+  "version": "1.2.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -51,20 +51,15 @@
       }
     },
     "@tokenizer/token": {
-      "version": "0.1.1",
-      "resolved": "https://registry.npmjs.org/@tokenizer/token/-/token-0.1.1.tgz",
-      "integrity": "sha512-XO6INPbZCxdprl+9qa/AAbFFOMzzwqYxpjPgLICrMD6C2FCw6qfJOPcBk6JqqPLSaZ/Qx87qn4rpPmPMwaAK6w=="
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/@tokenizer/token/-/token-0.3.0.tgz",
+      "integrity": "sha512-OvjF+z51L3ov0OyAU0duzsYuvO01PH7x4t6DJx+guahgTnBHkhJdG7soQeTSFLWN3efnHyibZ4Z8l2EuWwJN3A=="
     },
     "@types/color-name": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/@types/color-name/-/color-name-1.1.1.tgz",
       "integrity": "sha512-rr+OQyAjxze7GgWrSaJwydHStIhHq2lvY3BOC2Mj7KnzI7XK0Uw1TOOdI9lDoajEbSWLiYgoo4f1R51erQfhPQ==",
       "dev": true
-    },
-    "@types/debug": {
-      "version": "4.1.5",
-      "resolved": "https://registry.npmjs.org/@types/debug/-/debug-4.1.5.tgz",
-      "integrity": "sha512-Q1y515GcOdTHgagaVFhHnIFQ38ygs/kmxdNpvpou+raI9UO3YZcHDngBSYKQklcKlvA7iuQlmIKbzvmxcOE9CQ=="
     },
     "@types/eslint-visitor-keys": {
       "version": "1.0.0",
@@ -3129,14 +3124,13 @@
       }
     },
     "file-type": {
-      "version": "14.6.0",
-      "resolved": "https://registry.npmjs.org/file-type/-/file-type-14.6.0.tgz",
-      "integrity": "sha512-/Lg6yw7NtOVBe4wynSTDGyL32Jm+mqjYA7wZScjnEjYN1a68fhFhE75V2YEQPAfCoVtq6Mi02thUEYiOfTgLnQ==",
+      "version": "16.5.3",
+      "resolved": "https://registry.npmjs.org/file-type/-/file-type-16.5.3.tgz",
+      "integrity": "sha512-uVsl7iFhHSOY4bEONLlTK47iAHtNsFHWP5YE4xJfZ4rnX7S1Q3wce09XgqSC7E/xh8Ncv/be1lNoyprlUH/x6A==",
       "requires": {
-        "readable-web-to-node-stream": "^2.0.0",
-        "strtok3": "^6.0.0",
-        "token-types": "^2.0.0",
-        "typedarray-to-buffer": "^3.1.5"
+        "readable-web-to-node-stream": "^3.0.0",
+        "strtok3": "^6.2.4",
+        "token-types": "^4.1.1"
       }
     },
     "file-uri-to-path": {
@@ -4005,7 +3999,8 @@
     "is-typedarray": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/is-typedarray/-/is-typedarray-1.0.0.tgz",
-      "integrity": "sha1-5HnICFjfDBsR3dppQPlgEfzaSpo="
+      "integrity": "sha1-5HnICFjfDBsR3dppQPlgEfzaSpo=",
+      "optional": true
     },
     "is-windows": {
       "version": "1.0.2",
@@ -4960,24 +4955,24 @@
       "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
     },
     "music-metadata": {
-      "version": "6.4.0",
-      "resolved": "https://registry.npmjs.org/music-metadata/-/music-metadata-6.4.0.tgz",
-      "integrity": "sha512-oNkXjiZAFPFDoN006+rEJL/plISMa7odQzFLXYdY7AeoqPLPCFBmNaB9L3llndPmA/eKU0BJoX3mpZoyRL7avg==",
+      "version": "7.11.4",
+      "resolved": "https://registry.npmjs.org/music-metadata/-/music-metadata-7.11.4.tgz",
+      "integrity": "sha512-pEaS/vRo0zCAWJ0y5zZ5ruM8CvPPJ/VXbevRMUVkZkWN8rZAQun04xx09/3/PV0qS3nlrzPUDCRK6jDrbGVtUg==",
       "requires": {
         "content-type": "^1.0.4",
-        "debug": "^4.1.0",
-        "file-type": "^14.3.0",
+        "debug": "^4.3.2",
+        "file-type": "16.5.3",
         "media-typer": "^1.1.0",
-        "strtok3": "^6.0.0",
-        "token-types": "^2.0.0"
+        "strtok3": "^6.2.4",
+        "token-types": "^4.1.1"
       },
       "dependencies": {
         "debug": {
-          "version": "4.1.1",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
-          "integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
+          "version": "4.3.2",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.2.tgz",
+          "integrity": "sha512-mOp8wKcvj7XxC78zLgw/ZA+6TSgkoE2C/ienthhRD298T7UNwAg9diBpLRxC0mOezLl4B0xV7M0cCO6P/O0Xhw==",
           "requires": {
-            "ms": "^2.1.1"
+            "ms": "2.1.2"
           }
         },
         "media-typer": {
@@ -5555,9 +5550,9 @@
       }
     },
     "peek-readable": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/peek-readable/-/peek-readable-3.1.0.tgz",
-      "integrity": "sha512-KGuODSTV6hcgdZvDrIDBUkN0utcAVj1LL7FfGbM0viKTtCHmtZcuEJ+lGqsp0fTFkGqesdtemV2yUSMeyy3ddA=="
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/peek-readable/-/peek-readable-4.0.1.tgz",
+      "integrity": "sha512-7qmhptnR0WMSpxT5rMHG9bW/mYSR1uqaPFj2MHvT+y/aOUu6msJijpKt5SkTDKySwg65OWG2JwTMBlgcbwMHrQ=="
     },
     "performance-now": {
       "version": "2.1.0",
@@ -5844,9 +5839,24 @@
       }
     },
     "readable-web-to-node-stream": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/readable-web-to-node-stream/-/readable-web-to-node-stream-2.0.0.tgz",
-      "integrity": "sha512-+oZJurc4hXpaaqsN68GoZGQAQIA3qr09Or4fqEsargABnbe5Aau8hFn6ISVleT3cpY/0n/8drn7huyyEvTbghA=="
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/readable-web-to-node-stream/-/readable-web-to-node-stream-3.0.2.tgz",
+      "integrity": "sha512-ePeK6cc1EcKLEhJFt/AebMCLL+GgSKhuygrZ/GLaKZYEecIgIECf4UaUuaByiGtzckwR4ain9VzUh95T1exYGw==",
+      "requires": {
+        "readable-stream": "^3.6.0"
+      },
+      "dependencies": {
+        "readable-stream": {
+          "version": "3.6.0",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.0.tgz",
+          "integrity": "sha512-BViHy7LKeTz4oNnkcLJ+lVSL6vpiFeX6/d3oSH8zCW7UxP2onchk+vTGB143xuFjHS3deTgkKoXXymXqymiIdA==",
+          "requires": {
+            "inherits": "^2.0.3",
+            "string_decoder": "^1.1.1",
+            "util-deprecate": "^1.0.1"
+          }
+        }
+      }
     },
     "readdirp": {
       "version": "2.2.1",
@@ -6179,6 +6189,11 @@
       "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-1.0.0.tgz",
       "integrity": "sha1-2kL0l0DAtC2yypcoVxyxkMmO/qM=",
       "dev": true
+    },
+    "shell-quote": {
+      "version": "1.7.2",
+      "resolved": "https://registry.npmjs.org/shell-quote/-/shell-quote-1.7.2.tgz",
+      "integrity": "sha512-mRz/m/JVscCrkMyPqHc/bczi3OQHkLTqXHEFu0zDhK/qfv3UcOA4SVmRCLmos4bhjr9ekVQubj/R7waKapmiQg=="
     },
     "signal-exit": {
       "version": "3.0.3",
@@ -6689,29 +6704,12 @@
       "dev": true
     },
     "strtok3": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/strtok3/-/strtok3-6.0.0.tgz",
-      "integrity": "sha512-ZXlmE22LZnIBvEU3n/kZGdh770fYFie65u5+2hLK9s74DoFtpkQIdBZVeYEzlolpGa+52G5IkzjUWn+iXynOEQ==",
+      "version": "6.2.4",
+      "resolved": "https://registry.npmjs.org/strtok3/-/strtok3-6.2.4.tgz",
+      "integrity": "sha512-GO8IcFF9GmFDvqduIspUBwCzCbqzegyVKIsSymcMgiZKeCfrN9SowtUoi8+b59WZMAjIzVZic/Ft97+pynR3Iw==",
       "requires": {
-        "@tokenizer/token": "^0.1.1",
-        "@types/debug": "^4.1.5",
-        "debug": "^4.1.1",
-        "peek-readable": "^3.1.0"
-      },
-      "dependencies": {
-        "debug": {
-          "version": "4.1.1",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
-          "integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
-          "requires": {
-            "ms": "^2.1.1"
-          }
-        },
-        "ms": {
-          "version": "2.1.2",
-          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
-          "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
-        }
+        "@tokenizer/token": "^0.3.0",
+        "peek-readable": "^4.0.1"
       }
     },
     "supports-color": {
@@ -6872,12 +6870,19 @@
       "integrity": "sha512-yaOH/Pk/VEhBWWTlhI+qXxDFXlejDGcQipMlyxda9nthulaxLZUNcUqFxokp0vcYnvteJln5FNQDRrxj3YcbVw=="
     },
     "token-types": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/token-types/-/token-types-2.0.0.tgz",
-      "integrity": "sha512-WWvu8sGK8/ZmGusekZJJ5NM6rRVTTDO7/bahz4NGiSDb/XsmdYBn6a1N/bymUHuWYTWeuLUg98wUzvE4jPdCZw==",
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/token-types/-/token-types-4.1.1.tgz",
+      "integrity": "sha512-hD+QyuUAyI2spzsI0B7gf/jJ2ggR4RjkAo37j3StuePhApJUwcWDjnHDOFdIWYSwNR28H14hpwm4EI+V1Ted1w==",
       "requires": {
-        "@tokenizer/token": "^0.1.0",
-        "ieee754": "^1.1.13"
+        "@tokenizer/token": "^0.3.0",
+        "ieee754": "^1.2.1"
+      },
+      "dependencies": {
+        "ieee754": {
+          "version": "1.2.1",
+          "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.2.1.tgz",
+          "integrity": "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA=="
+        }
       }
     },
     "tough-cookie": {
@@ -6966,14 +6971,6 @@
       "version": "0.0.6",
       "resolved": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz",
       "integrity": "sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c="
-    },
-    "typedarray-to-buffer": {
-      "version": "3.1.5",
-      "resolved": "https://registry.npmjs.org/typedarray-to-buffer/-/typedarray-to-buffer-3.1.5.tgz",
-      "integrity": "sha512-zdu8XMNEDepKKR+XYOXAVPtWui0ly0NtohUscw+UmaHiAWT8hrV1rr//H6V+0DvJ3OQ19S979M0laLfX8rm82Q==",
-      "requires": {
-        "is-typedarray": "^1.0.0"
-      }
     },
     "typescript": {
       "version": "3.8.3",

--- a/package.json
+++ b/package.json
@@ -34,7 +34,8 @@
     "karma-mocha-reporter": "2.2.5",
     "karma-webpack": "3.0.0",
     "mocha": "5.2.0",
-    "music-metadata": "^6.4.0",
+    "music-metadata": "^7.9.1",
+    "shell-quote": "^1.7.2",
     "springroll-container": "^1.1.3",
     "typescript": "^3.8.3",
     "webpack": "4.16.5"

--- a/src/tools/AssetScanner.js
+++ b/src/tools/AssetScanner.js
@@ -4,6 +4,7 @@ const promisify = require('util').promisify;
 const imageSize = require('image-size');
 const musicMetadata = require('music-metadata');
 const { execSync } = require('child_process');
+const quote = require('shell-quote').quote;
 
 const { parseSRASConfig } = require('../lib/srasConfig');
 const { formatMsToHRT } = require('../lib/format');
@@ -130,10 +131,10 @@ class AssetScanner {
 
       const fileName = filePath.split('\\').pop();
 
-      // The command to be passed to ffmpeg. 
-      let ffmpegCommand = 
-      ffmpegPath + 
-      ` -i ${filePath} -af loudnorm=I=-16:dual_mono=true:TP=-1.5:LRA=11:print_format=summary` + 
+      // The command to be passed to ffmpeg.
+      let ffmpegCommand =
+      ffmpegPath +
+      ` -i ${quote([filePath])} -af loudnorm=I=-16:dual_mono=true:TP=-1.5:LRA=11:print_format=summary` +
       ` -f null - 2>&1`;
 
       


### PR DESCRIPTION
The scanner was failing for a game due to two issues. 
1) `TypeError: buf.readInt16BE is not a function` which seems to be tied to the music-metadata package ( https://github.com/Borewit/music-metadata/issues/856 ) so I set music-metadata to v7.9.1 though possibly would be better to go with latest. I was uncertain of breaking changes down the road or node requirements beyond 10.24.1.
2) A particular game I was running the scanner on is failing due to having asset names that contain spaces. Using "shell-quote" on `filePath` is the proposed solution, but you all may have a preference for a different package. 

I did test these changes using bash on macOS, but am submitting the above more as place markers as I know this is a critical portion of the build pipeline.