### PR TITLE
Pin typescript to ~5.3.3 for parser compatibility

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.2.2] - 2026-07-16
+
+### Fixed
+
+- Pin `typescript` to `~5.3.3` to keep it compatible with the bundled `@typescript-eslint/parser@5.x`. TypeScript 7.0 was being pulled in transitively on fresh installs, causing every lint run to crash with `TypeError: Failed to load parser '@typescript-eslint/parser' ... Cannot read properties of undefined (reading 'BarBarToken')`. This broke linting across all consuming projects with no code changes on their end.
+
 ## [2.2.1] - 2025-03-13
 
 - Switch error count check in FileLinter.js to properly check for any error reports

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "springroll-automated-qa",
-  "version": "2.2.1",
+  "version": "2.2.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "springroll-automated-qa",
-      "version": "2.2.1",
+      "version": "2.2.2",
       "license": "ISC",
       "dependencies": {
         "@typescript-eslint/eslint-plugin": "^5.47.0",
@@ -31,6 +31,7 @@
         "music-metadata": "^7.9.1",
         "shell-quote": "^1.7.4",
         "springroll-container": "^1.1.3",
+        "typescript": "~5.3.3",
         "webpack": "^5.75.0"
       },
       "bin": {
@@ -4160,10 +4161,10 @@
       "integrity": "sha512-/aCDEGatGvZ2BIk+HmLf4ifCJFwvKFNb9/JeZPMulfgFracn9QFcAf5GO8B/mweUjSoblS5In0cWhqpfs/5PQA=="
     },
     "node_modules/typescript": {
-      "version": "5.6.3",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.6.3.tgz",
-      "integrity": "sha512-hjcS1mhfuyi4WW8IWtjP7brDrG2cuDZukyrYrSauoXGNgx0S7zceP07adYkJycEr56BOUTNPzbInooiN3fn1qw==",
-      "peer": true,
+      "version": "5.3.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.3.3.tgz",
+      "integrity": "sha512-pXWcraxM0uxAS+tN0AG/BF2TyqmHO014Z070UsJ+pFvYuRSq8KH8DmWpnbXe0pEPDHXZV3FcAbJkijJ5oNEnWw==",
+      "license": "Apache-2.0",
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "springroll-automated-qa",
-  "version": "2.2.1",
+  "version": "2.2.2",
   "description": "An automated QA tool for SpringRoll games",
   "main": "src/index.js",
   "bin": {
@@ -39,6 +39,7 @@
     "music-metadata": "^7.9.1",
     "shell-quote": "^1.7.4",
     "springroll-container": "^1.1.3",
+    "typescript": "~5.3.3",
     "webpack": "^5.75.0"
   },
   "devDependencies": {


### PR DESCRIPTION
## Problem

Linting started failing across **all** consuming projects — including repos with no code changes — with:

```
TypeError: Failed to load parser '@typescript-eslint/parser' declared in '--config':
Cannot read properties of undefined (reading 'BarBarToken')
    at .../springroll-automated-qa/node_modules/@typescript-eslint/typescript-estree/dist/node-utils.js:35:16
```

## Root cause

`springroll-automated-qa` bundles `@typescript-eslint/parser@5.x` (via `^5.47.0`), which only supports **TypeScript < 5.4**. But `typescript` was never pinned, so it was pulled in transitively. When **TypeScript 7.0** was published to npm, every fresh install (`npm i -g springroll-automated-qa` in `lint.sh`) resolved to it. The v5 parser's `typescript-estree` reads `ts.SyntaxKind.BarBarToken`, which no longer exists in TS 7 → crash on load, before any project code is even parsed.

Nothing changed in the consuming games — the trigger was purely the upstream TypeScript release combined with our floating dependency.

Note: pinning `typescript` in a *consuming project's* `package.json` does **not** fix this, because `srlint` runs as a global install and resolves `typescript` from its own `node_modules`. The fix has to live here.

## Fix

Pin `typescript` to `~5.3.3` (the newest release within the bundled parser's supported range) as a direct dependency, so the whole tree — including `typescript-estree` — resolves to a compatible version.

## Verification

Reproduced the crash against a real game repo, then confirmed with this build:

- `srlint -p src/` on the affected game repo → **exit 0, no crash** (was crashing on load before).
- Sanity-checked that linting still *works*: a file with `var`, `==`, and `for...of` is correctly flagged (`no-var`, `eqeqeq`, `no-restricted-syntax`) — so this restores real linting, not a silent pass.
- Lockfile diff is minimal: `typescript` moves from a floating `5.6.3` (peer) to a pinned `5.3.3`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)